### PR TITLE
Cache the results of .grep

### DIFF
--- a/bench
+++ b/bench
@@ -71,7 +71,7 @@ sub guess-checkouts(:@compilers, :@extras, :&good-tag) {
     my %tags := known-tags(@compilers);
 
     my %default;
-    %default{$_} = %tags{$_}.grep(&good-tag) for @compilers;
+    %default{$_} = %tags{$_}.grep(&good-tag).cache for @compilers;
 
     sort gather {
         for %default.kv -> $compiler, @defaults {


### PR DESCRIPTION
It now produces a `Seq`, so it needs to be cached to be stored in a hash.